### PR TITLE
reduce animation jank by deferring React updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,26 @@ export function Providers({ children }: { children: React.ReactNode }) {
 }
 ```
 
+## Performance Optimization
+
+When overlapping exit animations with page loading (common for smooth transitions), React rendering can cause animation jank. Use `requestAnimationFrame` and `startTransition` to prioritize animation performance:
+
+```tsx
+import { startTransition } from "react";
+
+enter={(next) => {
+  const tl = gsap.timeline()
+    .to(".overlay", { y: "-100%", duration: 0.5 })
+    .call(() => {
+      requestAnimationFrame(() => startTransition(next));
+    }, undefined, "<50%"); // Overlap timing preserved
+    
+  return () => tl.kill();
+}}
+```
+
+This prevents React updates from interfering with your animation timeline while maintaining visual timing.
+
 ## API
 
 ### `TransitionRouter`

--- a/example/app/providers.tsx
+++ b/example/app/providers.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, startTransition } from "react";
 import { gsap } from "gsap";
 import { TransitionRouter } from "next-transition-router";
 
@@ -66,7 +66,12 @@ export function Providers({ children }: { children: React.ReactNode }) {
             },
             "<50%",
           )
-          .call(next, undefined, "<50%");
+          .call(() => {
+            // Defer React updates to prevent jank during animation
+            requestAnimationFrame(() => {
+              startTransition(next);
+            });
+          }, undefined, "<50%");
 
         return () => {
           tl.kill();


### PR DESCRIPTION
This pull request introduces a performance optimization for animations in React applications, specifically targeting scenarios where exit animations overlap with page loading. The changes aim to reduce animation jank by deferring React updates during animations using `requestAnimationFrame` and `startTransition`.

### Performance Optimization for Animations:

* **Documentation Update**: Added a new "Performance Optimization" section to the `README.md`, explaining how to use `requestAnimationFrame` and `startTransition` to improve animation performance during transitions. Includes a code example demonstrating the approach.

* **Code Update in `example/app/providers.tsx`**:
  - Imported `startTransition` to enable deferring React updates.
  - Updated the animation timeline in the `Providers` component to wrap the `next` callback with `requestAnimationFrame` and `startTransition`, ensuring smoother animations by prioritizing rendering performance.